### PR TITLE
Fix: Ensure consistent working directory for Claude sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,10 +87,11 @@ go install ./cmd/repo-claude
 
 4. **Scope Management** (`pkg/manager/scopes.go`)
    - Launches Claude Code instances with multi-repository context
-   - Sets environment variables (RC_SCOPE_ID, RC_SCOPE_NAME, RC_SCOPE_REPOS, RC_WORKSPACE_ROOT)
+   - Sets environment variables (RC_SCOPE_ID, RC_SCOPE_NAME, RC_SCOPE_REPOS, RC_WORKSPACE_ROOT, RC_PROJECT_ROOT)
    - Supports scope dependencies and auto-start configuration
    - Creates CLAUDE.md files in each repository for workspace context
    - Terminal tab management with fallback to windows
+   - Working directory set to project root for consistency
 
 ### Workspace Structure
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,8 @@ When you start a scope with `rc start backend`, repo-claude:
    - `RC_SCOPE_ID`: Unique identifier for the scope instance
    - `RC_SCOPE_NAME`: The scope name (e.g., "backend")
    - `RC_SCOPE_REPOS`: Comma-separated list of repositories in scope
-   - `RC_WORKSPACE_ROOT`: Root directory of the workspace
+   - `RC_WORKSPACE_ROOT`: Path where repositories are cloned (workspace directory)
+   - `RC_PROJECT_ROOT`: Path where repo-claude.yaml is located (project root)
 
 3. **Provides context** through:
    - **System prompt**: Includes scope name, description, and repositories

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -207,7 +207,8 @@ Claude sessions now receive these environment variables:
 - `RC_SCOPE_ID`: Unique scope instance ID
 - `RC_SCOPE_NAME`: The scope name
 - `RC_SCOPE_REPOS`: Comma-separated repo list
-- `RC_WORKSPACE_ROOT`: Workspace root directory
+- `RC_WORKSPACE_ROOT`: Path where repositories are cloned (workspace directory)
+- `RC_PROJECT_ROOT`: Path where repo-claude.yaml is located (project root)
 
 ## Tips for Effective Scopes
 

--- a/docs/implementation-plan-scopes.md
+++ b/docs/implementation-plan-scopes.md
@@ -54,7 +54,8 @@ Successfully implemented environment variable passing to Claude sessions:
 - `RC_SCOPE_ID`: Unique identifier for the scope instance
 - `RC_SCOPE_NAME`: Human-readable scope name  
 - `RC_SCOPE_REPOS`: Comma-separated list of repositories in scope
-- `RC_WORKSPACE_ROOT`: Root directory of the workspace
+- `RC_WORKSPACE_ROOT`: Path where repositories are cloned (workspace directory)
+- `RC_PROJECT_ROOT`: Path where repo-claude.yaml is located (project root)
 
 ### Phase 2: Dynamic Scope Tracking ✅
 

--- a/internal/manager/scopes.go
+++ b/internal/manager/scopes.go
@@ -38,11 +38,9 @@ func (m *Manager) StartScopeWithOptions(scopeName string, opts StartOptions) err
 		return fmt.Errorf("no repositories found for scope %s", scopeName)
 	}
 
-	// Use current directory as working directory
-	workDir, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("getting current directory: %w", err)
-	}
+	// Use project root as working directory for consistency
+	// This ensures all scopes start from the same location
+	workDir := m.ProjectPath
 
 	location := "new tab"
 	if opts.NewWindow {
@@ -62,13 +60,14 @@ func (m *Manager) StartScopeWithOptions(scopeName string, opts StartOptions) err
 		"RC_SCOPE_ID":        generateScopeID(scopeName),
 		"RC_SCOPE_NAME":      scopeName,
 		"RC_SCOPE_REPOS":     strings.Join(repos, ","),
-		"RC_WORKSPACE_ROOT":  workDir,
+		"RC_WORKSPACE_ROOT":  m.WorkspacePath,  // Path where repositories are cloned
+		"RC_PROJECT_ROOT":    m.ProjectPath,     // Path where repo-claude.yaml is located
 	}
 
 	cmd := createNewTerminalCommand(scopeName, workDir, scopeConfig.Model, systemPrompt, envVars, opts.NewWindow)
 
 	// Start the command
-	err = cmd.Start()
+	err := cmd.Start()
 	if err != nil {
 		// If we tried to open in a tab and it failed, try opening in a new window
 		if !opts.NewWindow && runtime.GOOS == "darwin" {

--- a/internal/manager/scopes_test.go
+++ b/internal/manager/scopes_test.go
@@ -1,0 +1,78 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/taokim/repo-claude/internal/config"
+)
+
+func TestResolveScopeRepos(t *testing.T) {
+	m := &Manager{
+		Config: &config.Config{
+			Workspace: config.WorkspaceConfig{
+				Manifest: config.Manifest{
+					Projects: []config.Project{
+						{Name: "backend-api"},
+						{Name: "backend-db"},
+						{Name: "frontend-web"},
+						{Name: "frontend-mobile"},
+						{Name: "shared-lib"},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		patterns []string
+		expected []string
+	}{
+		{
+			name:     "Exact match",
+			patterns: []string{"backend-api", "frontend-web"},
+			expected: []string{"backend-api", "frontend-web"},
+		},
+		{
+			name:     "Wildcard match",
+			patterns: []string{"backend-*"},
+			expected: []string{"backend-api", "backend-db"},
+		},
+		{
+			name:     "Multiple prefix wildcards",
+			patterns: []string{"frontend-*", "shared-*"},
+			expected: []string{"frontend-mobile", "frontend-web", "shared-lib"},
+		},
+		{
+			name:     "All repos",
+			patterns: []string{"*"},
+			expected: []string{"backend-api", "backend-db", "frontend-mobile", "frontend-web", "shared-lib"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := m.resolveScopeRepos(tt.patterns)
+			
+			// Sort both slices for comparison
+			if len(result) != len(tt.expected) {
+				t.Errorf("Expected %d repos, got %d", len(tt.expected), len(result))
+				return
+			}
+			
+			// Check all expected repos are present
+			for _, exp := range tt.expected {
+				found := false
+				for _, res := range result {
+					if res == exp {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected repo %s not found in result", exp)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes the working directory consistency issue when starting Claude sessions with scopes. Previously, the working directory was set to the current directory using `os.Getwd()`, which could vary depending on where the command was run. Now it's consistently set to the project root directory.

## Problem
- Working directory changed based on where `rc start` was executed
- Made relative paths unreliable across different invocations
- Caused confusion when switching between scopes

## Solution
- Set working directory to project root (where `repo-claude.yaml` is located)
- Add `RC_PROJECT_ROOT` environment variable for clarity
- Properly set `RC_WORKSPACE_ROOT` to the workspace directory

## Changes
### Code Changes
- **internal/manager/scopes.go**: 
  - Changed from `os.Getwd()` to `m.ProjectPath` for consistent working directory
  - Added `RC_PROJECT_ROOT` environment variable
  - Fixed `RC_WORKSPACE_ROOT` to point to workspace path

### Documentation Updates
- Updated README.md with new environment variables
- Updated CLAUDE.md with working directory behavior
- Updated migration and implementation docs

### Tests
- Added `scopes_test.go` with tests for repository resolution

## Benefits
✅ **Consistency**: All scopes start from the same location regardless of where command is run
✅ **Clarity**: Two distinct environment variables for project root vs workspace root  
✅ **Predictability**: Relative paths now work reliably across all sessions

## Test plan
- [x] All existing tests pass
- [x] Added new test for repository resolution
- [x] Built and tested binary locally
- [ ] Manual testing of scope startup with different working directories

🤖 Generated with [Claude Code](https://claude.ai/code)